### PR TITLE
Created tests and the 'valid_move?' method for the Rook piece

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -10,7 +10,7 @@ class Piece < ApplicationRecord
     [x,y].all? { |e| (e >= 0) && (e <= 7) }
   end
 
-  def is_obstructed?(x,y)
+  def is_obstructed?(x,y) #checking if obstructed in any direction
     v_obs?(x,y) || h_obs?(x,y) || d_obs?(x,y) || invalid(x,y)
   end
 
@@ -32,6 +32,7 @@ class Piece < ApplicationRecord
         end
       end
     end
+    return false
   end
 
   def h_obs?(x,y)
@@ -52,6 +53,7 @@ class Piece < ApplicationRecord
         end
       end
     end
+    return false
   end
 
   def d_obs?(x,y)

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -1,22 +1,12 @@
 class Rook < Piece
 
   def valid_move?(x,y)
-    return false unless super(x,y)              #if move is invalid, it will return false immediately vs going thrrough code line by line - saves time. 
+    return false unless super(x,y)             
     current_loc_x = self.location_x             
     current_loc_y = self.location_y 
     
-    if current_loc_x == x && current_loc_y != y #checks if move is valid vertically
-      return v_obs?(x,y)                        # i initially had "return !v_obs?(x,y)" because it's supposed to return opp of v_obs. so if v_obs is false, returns true, 
-    end                                         # i.e. it is true the move is valid because it's not obstructed, but for some reason that kept causing my test to fail. i removed the ! and now it works but the logic doesn't make sense because return v_obs?(x,y) is basically "return false" because it's not obstructed and I want it to return true as in "it's true, it's valid"
-
-    if current_loc_y == y && current_loc_x != x #checks if move is valid horizontally
-      return !h_obs?(x,y)                       # returns opp of h_obs. so if h_obs is false, returns true, 
-    end                                         # i.e. it is true the move is valid
-
-    return false                                #if move is neither valid vertically or horizontally, then return false.
+    return !v_obs?(x,y) if current_loc_x == x && current_loc_y != y   
+    return !h_obs?(x,y)  if current_loc_y == y && current_loc_x != x
+                                                                    
   end
 end
-
-
-
-

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -1,2 +1,22 @@
 class Rook < Piece
+
+  def valid_move?(x,y)
+    return false unless super(x,y)              #if move is invalid, it will return false immediately vs going thrrough code line by line - saves time. 
+    current_loc_x = self.location_x             
+    current_loc_y = self.location_y 
+    
+    if current_loc_x == x && current_loc_y != y #checks if move is valid vertically
+      return v_obs?(x,y)                        # i initially had "return !v_obs?(x,y)" because it's supposed to return opp of v_obs. so if v_obs is false, returns true, 
+    end                                         # i.e. it is true the move is valid because it's not obstructed, but for some reason that kept causing my test to fail. i removed the ! and now it works but the logic doesn't make sense because return v_obs?(x,y) is basically "return false" because it's not obstructed and I want it to return true as in "it's true, it's valid"
+
+    if current_loc_y == y && current_loc_x != x #checks if move is valid horizontally
+      return !h_obs?(x,y)                       # returns opp of h_obs. so if h_obs is false, returns true, 
+    end                                         # i.e. it is true the move is valid
+
+    return false                                #if move is neither valid vertically or horizontally, then return false.
+  end
 end
+
+
+
+

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -7,6 +7,7 @@ class Rook < Piece
     
     return !v_obs?(x,y) if current_loc_x == x && current_loc_y != y   
     return !h_obs?(x,y)  if current_loc_y == y && current_loc_x != x
-                                                                    
+
+    return false                                            
   end
 end

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -27,4 +27,12 @@ RSpec.describe Rook, type: :model do
     pawn = Pawn.create(location_x: 0, location_y: 5, game_id: game.id)
     expect(rook.valid_move?(0,7)).to be false
   end
+
+  it "shouldn't allow a rook to move non-linear (diagonal) on the board" do
+    game = FactoryBot.create(:game)
+    rook = Rook.create(location_x: 0, location_y: 3, game_id: game.id)
+    expect(rook.valid_move?(3,4)).to be false
+    expect(rook.valid_move?(4,5)).to be false
+    expect(rook.valid_move?(5,6)).to be false
+  end
 end

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -4,36 +4,27 @@ RSpec.describe Rook, type: :model do
 
   it "should allow a rook to move vertically on board" do
     game = FactoryBot.create(:game)
-    piece1 = Rook.create(location_x: 1, location_y: 1, game_id: game.id)
-    expect(piece1.valid_move?(1,6)).to be true
+    rook = Rook.create(location_x: 4, location_y: 3, game_id: game.id)
+    expect(rook.valid_move?(4,5)).to be true
   end
 
   it "should allow a rook to move horizontally on board" do
     game = FactoryBot.create(:game)
-    piece1 = Rook.create(location_x: 3, location_y: 3, game_id: game.id)
-    expect(piece1.valid_move?(6,3)).to be true
+    rook = Rook.create(location_x: 3, location_y: 3, game_id: game.id)
+    expect(rook.valid_move?(6,3)).to be true
 
   end
 
   it "shouldn't allow moves outside the chessboard" do
     game = FactoryBot.create(:game)
-    piece1 = Rook.create(location_x: 0, location_y: 0, game_id: game.id)
-    expect(piece1.valid_move?(8,8)).to be false
-
+    rook = Rook.create(location_x: 5, location_y: 5, game_id: game.id)
+    expect(rook.valid_move?(8,8)).to be false
   end
 
+  it "shouldn't allow rook to move past an obstruction" do
+    game = FactoryBot.create(:game)
+    rook = Rook.create(location_x: 0, location_y: 3, game_id: game.id)
+    pawn = Pawn.create(location_x: 0, location_y: 5, game_id: game.id)
+    expect(rook.valid_move?(0,7)).to be false
+  end
 end
-
-=begin 
-  questions to review w/ roye
-  added tests for moving Hor & Ver. Check obstructed method specs - do they cover the following situations:
-    - if cur_loc is (1,3), dest is (6,3) but there's a team piece at (3,3). does obstructed method create an invalid path error
-      because can't jump pieces
-    - if cur_loc is (1,3), dest is (6,3) but there's an enemy at (3,3). does captured method know to capture the enemy piece
-      and update rook dest to (3,3) vs (6,3)? rook can't move forward, ie. can't capture then continue w initial dest plan
-    - if theres a team piece at destination. does obstructed method cite an error message "invalid path"?
-
-    - in the piece_spec.rb - why do we create pieces w/ some tests and find the pieces with others?
-    - move_to method in piece model accounts for destinations.
-    - recieving failure errow in test w/ line 27
-=end

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -1,4 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe Rook, type: :model do
+
+  it "should allow a rook to move vertically on board" do
+    game = FactoryBot.create(:game)
+    piece1 = Rook.create(location_x: 1, location_y: 1, game_id: game.id)
+    expect(piece1.valid_move?(1,6)).to be true
+  end
+
+  it "should allow a rook to move horizontally on board" do
+    game = FactoryBot.create(:game)
+    piece1 = Rook.create(location_x: 3, location_y: 3, game_id: game.id)
+    expect(piece1.valid_move?(6,3)).to be true
+
+  end
+
+  it "shouldn't allow moves outside the chessboard" do
+    game = FactoryBot.create(:game)
+    piece1 = Rook.create(location_x: 0, location_y: 0, game_id: game.id)
+    expect(piece1.valid_move?(8,8)).to be false
+
+  end
+
 end
+
+=begin 
+  questions to review w/ roye
+  added tests for moving Hor & Ver. Check obstructed method specs - do they cover the following situations:
+    - if cur_loc is (1,3), dest is (6,3) but there's a team piece at (3,3). does obstructed method create an invalid path error
+      because can't jump pieces
+    - if cur_loc is (1,3), dest is (6,3) but there's an enemy at (3,3). does captured method know to capture the enemy piece
+      and update rook dest to (3,3) vs (6,3)? rook can't move forward, ie. can't capture then continue w initial dest plan
+    - if theres a team piece at destination. does obstructed method cite an error message "invalid path"?
+
+    - in the piece_spec.rb - why do we create pieces w/ some tests and find the pieces with others?
+    - move_to method in piece model accounts for destinations.
+    - recieving failure errow in test w/ line 27
+=end


### PR DESCRIPTION
Create the valid_move? logic for rook pieces, but my vertical tests kept failing. 

On line 9 in the models/rook.rb file, I initially had **return !v_obs?(x,y)**.

That piece of code was supposed to return **true** because _v_obs?(x,y)_ should've outputted **false**. 

However, I kept receiving an error for that line, even though the logic makes sense. I removed the ! and now it works, but the logic doens't make sense because by removing !, it returns true as in "yes, it is vertically obstructed". 

I could be missing something, but any insight would be appreciated. Thanks!

![screen shot 2018-05-31 at 10 34 17 am](https://user-images.githubusercontent.com/30423900/40788491-35c57b9a-64be-11e8-8b91-29440d8c11b9.png)


